### PR TITLE
Global functions beforeBench, afterBench, beforeSuite and afterSuite

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,26 +44,26 @@ $ $EDITOR tests.html
 
   <script src="bower_components/astrobench/dist/astrobench.js"></script>
   <script>
-    // A test suite begins with a call to the global function `suite` with two parameters:
-    // a string and a function.
-    // The string is a name or title for a spec suite – usually what is being tested.
-    // The function is a block of code that implements the suite.
+    // A test suite begins with a call to the global function `suite`
+    // with two parameters: a string and a function.
+    // The string is a name or title for a spec suite – usually what is being
+    // tested. The function is a block of code that implements the suite.
     suite('String matching', function(suite) {
       var text;
 
       // To help a test suite DRY up any duplicated setup code, provides
-      // the global `setup` functions.
-      // As the name implies the `setup` function is called once.
+      // the global `beforeBench` functions. As the name implies,
+      // this function is called once before each benchmark is executed.
       // You can store data in `suite` Object, or define necessary variables.
-      // Code from body of the function will be presented in UI.
-      setup(function() {
+      // Code from body of the functions will be presented in UI.
+      beforeBench(function() {
         suite.text = 'Hello world';
         text = 'Hello world';
       });
 
-      // Benchmark are defined by calling the global function `bench`,
+      // Benchmarks are defined by calling the global function `bench`,
       // which, like `suite` takes a string and a function.
-      // The string is the title of the test and the function is the test
+      // The string is the title of the test and the function is the test.
       bench('String#match', function() {
         !! text.match(/o/);
       });

--- a/examples/bench.js
+++ b/examples/bench.js
@@ -9,7 +9,7 @@ suite('A suite', function() {
 });
 
 suite('B suite', function(suite) {
-  setup(function() {
+  beforeBench(function() {
     suite.text = 'Hello world';
   });
 

--- a/src/astrobench.js
+++ b/src/astrobench.js
@@ -184,9 +184,11 @@ window.suite = function(name, fn) {
     return new Suite(name, fn);
 };
 window.setup = setup;
+window.beforeSuite = beforeSuite;
 window.beforeBench = beforeBench;
 window.bench = bench;
 window.after = after;
+window.afterSuite = afterSuite;
 window.afterBench = afterBench;
 
 window.astrobench = run;

--- a/src/astrobench.js
+++ b/src/astrobench.js
@@ -15,6 +15,26 @@ var state = {
     index: 0
 };
 
+var deprecate = function(oldName, newName) {
+    console.log('The function "' + oldName + '" is deprecated. Use "' +
+        newName + '" instead.');
+}
+
+var Listeners = function() {
+    this.callbacks = [];
+    this.runner = this.run.bind(this);
+};
+
+Listeners.prototype.add = function(callback) {
+    this.callbacks.push(callback);
+}
+
+Listeners.prototype.run = function() {
+    this.callbacks.forEach(function (callback) {
+        callback();
+    });
+}
+
 var Suite = function(name, fn) {
     // update global state
     state.describes.push(this);
@@ -23,6 +43,8 @@ var Suite = function(name, fn) {
     this.id = _.uniqueId('suite');
     this.sandbox = {};
     this.suite = new Benchmark.Suite(name);
+    this.beforeBenchListeners = new Listeners();
+    this.afterBenchListeners = new Listeners();
 
     setTimeout(ui.drawSuite.bind(this, this));
 
@@ -31,11 +53,21 @@ var Suite = function(name, fn) {
 
 Suite.prototype = {
     setup: function(fn) {
+        deprecate('setup', 'beforeBench');
         this.setupFn = fn;
     },
 
     after: function(fn) {
+        deprecate('after', 'afterBench');
         this.afterFn = fn;
+    },
+
+    beforeBench: function(fn) {
+        this.beforeBenchListeners.add(fn);
+    },
+
+    afterBench: function(fn) {
+        this.afterBenchListeners.add(fn);
     },
 
     add: function(name, fn, options) {
@@ -50,6 +82,8 @@ Suite.prototype = {
 
         bench.originFn = fn;
         bench.originOption = options;
+        bench.on('start', this.beforeBenchListeners.runner);
+        bench.on('complete', this.afterBenchListeners.runner);
 
         setTimeout(ui.drawBench.bind(this, this, bench));
     },
@@ -88,6 +122,14 @@ var setup = function(fn) {
 
 var after = function(fn) {
     state.currentSuite.after(fn);
+};
+
+var beforeBench = function(fn) {
+    state.currentSuite.beforeBench(fn);
+};
+
+var afterBench = function(fn) {
+    state.currentSuite.afterBench(fn);
 };
 
 var run = function(options) {
@@ -132,7 +174,9 @@ window.suite = function(name, fn) {
     return new Suite(name, fn);
 };
 window.setup = setup;
+window.beforeBench = beforeBench;
 window.bench = bench;
 window.after = after;
+window.afterBench = afterBench;
 
 window.astrobench = run;

--- a/src/astrobench.js
+++ b/src/astrobench.js
@@ -43,6 +43,8 @@ var Suite = function(name, fn) {
     this.id = _.uniqueId('suite');
     this.sandbox = {};
     this.suite = new Benchmark.Suite(name);
+    this.beforeSuiteListeners = new Listeners();
+    this.afterSuiteListeners = new Listeners();
     this.beforeBenchListeners = new Listeners();
     this.afterBenchListeners = new Listeners();
 
@@ -60,6 +62,14 @@ Suite.prototype = {
     after: function(fn) {
         deprecate('after', 'afterBench');
         this.afterFn = fn;
+    },
+
+    beforeSuite: function(fn) {
+        this.beforeSuiteListeners.add(fn);
+    },
+
+    afterSuite: function(fn) {
+        this.afterSuiteListeners.add(fn);
     },
 
     beforeBench: function(fn) {

--- a/src/astrobench.js
+++ b/src/astrobench.js
@@ -134,6 +134,14 @@ var after = function(fn) {
     state.currentSuite.after(fn);
 };
 
+var beforeSuite = function(fn) {
+    state.currentSuite.beforeSuite(fn);
+};
+
+var afterSuite = function(fn) {
+    state.currentSuite.afterSuite(fn);
+};
+
 var beforeBench = function(fn) {
     state.currentSuite.beforeBench(fn);
 };

--- a/src/templates/suite.html
+++ b/src/templates/suite.html
@@ -8,6 +8,14 @@
 	<div class="suite-setup hidden">
 		<% if(suite.setupFn) { %>
 		<pre><code><%= hilite('// Preparation code\n') + hilite(fnstrip(suite.setupFn)) %></code></pre>
+		<% } else if(suite.beforeBenchListeners.callbacks.length) { %>
+		<pre><code><%=
+			hilite('// Preparation code\n') +
+			suite.beforeBenchListeners.callbacks
+				.map(function (callback) {
+					return hilite(fnstrip(callback));
+				})
+				.join('\n') %></code></pre>
 		<% } else { %>
 		<pre><code><%= hilite('// No preparation code') %></code></pre>
 		<% } %>

--- a/src/templates/suite.html
+++ b/src/templates/suite.html
@@ -7,16 +7,28 @@
 	</div>
 	<div class="suite-setup hidden">
 		<% if(suite.setupFn) { %>
-		<pre><code><%= hilite('// Preparation code\n') + hilite(fnstrip(suite.setupFn)) %></code></pre>
-		<% } else if(suite.beforeBenchListeners.callbacks.length) { %>
+		<pre><code><%= hilite('// Preparation code (deprecated)\n') + hilite(fnstrip(suite.setupFn)) %></code></pre>
+		<% } %>
+		<% if (suite.beforeSuiteListeners.callbacks.length) { %>
 		<pre><code><%=
-			hilite('// Preparation code\n') +
+			hilite('// Suite preparation code\n') +
+			suite.beforeSuiteListeners.callbacks
+				.map(function (callback) {
+					return hilite(fnstrip(callback));
+				})
+				.join('\n') %></code></pre>
+		<% } %>
+		<% if (suite.beforeBenchListeners.callbacks.length) { %>
+		<pre><code><%=
+			hilite('// Benchmark preparation code\n') +
 			suite.beforeBenchListeners.callbacks
 				.map(function (callback) {
 					return hilite(fnstrip(callback));
 				})
 				.join('\n') %></code></pre>
-		<% } else { %>
+		<% } %>
+		<% if (!(suite.setupFn || suite.beforeSuiteListeners.callbacks.length ||
+					   suite.beforeBenchListeners.callbacks.length)) { %>
 		<pre><code><%= hilite('// No preparation code') %></code></pre>
 		<% } %>
 	</div>


### PR DESCRIPTION
Introduces global functions `beforeBench`, `afterBench`, `beforeSuite` and `afterSuite` accepting a function callback with obvious functionality. Deprecates `setup` and `after` which behave like the last pair.

Attempts to fix #1.